### PR TITLE
pass context in a few more places

### DIFF
--- a/cmd/thirdweb/nft_drop_commands.go
+++ b/cmd/thirdweb/nft_drop_commands.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/thirdweb-dev/go-sdk/v2/thirdweb"
 )
 
@@ -83,7 +84,7 @@ var nftDropGetActiveCmd = &cobra.Command{
 			panic(err)
 		}
 
-		active, err := nftDrop.ClaimConditions.GetActive()
+		active, err := nftDrop.ClaimConditions.GetActive(context.Background())
 		if err != nil {
 			panic(err)
 		}
@@ -95,7 +96,7 @@ var nftDropGetActiveCmd = &cobra.Command{
 		fmt.Println("Price:", active.Price)
 		fmt.Println("Wait In Seconds", active.WaitInSeconds)
 
-		all, err := nftDrop.ClaimConditions.GetAll()
+		all, err := nftDrop.ClaimConditions.GetAll(context.Background())
 		if err != nil {
 			panic(err)
 		}
@@ -132,7 +133,7 @@ var nftDropClaimCmd = &cobra.Command{
 		emptyDrop, err := emptySdk.GetNFTDrop(nftDropContractAddress)
 
 		address := thirdwebSDK.GetSignerAddress().String()
-		claimArgs, err := emptyDrop.GetClaimArguments(context.Background(), address, 1)	
+		claimArgs, err := emptyDrop.GetClaimArguments(context.Background(), address, 1)
 		if err != nil {
 			panic(err)
 		}

--- a/thirdweb/common.go
+++ b/thirdweb/common.go
@@ -82,7 +82,7 @@ func convertToReadableQuantity(bn *big.Int, decimals int) string {
 }
 
 func convertQuantityToBigNumber(quantity string, decimals int) (*big.Int, error) {
-  if quantity == "unlimited" {
+	if quantity == "unlimited" {
 		MaxUint256 := new(big.Int).Sub(new(big.Int).Lsh(common.Big1, 256), common.Big1)
 		return MaxUint256, nil
 	} else {
@@ -374,9 +374,9 @@ func prepareClaim(
 				}
 
 				priceInProof, err = normalizePriceValue(
-					ctx, 
-					contractHelper.GetProvider(), 
-					flt, 
+					ctx,
+					contractHelper.GetProvider(),
+					flt,
 					snapshotEntry.CurrencyAddress,
 				)
 			}
@@ -406,16 +406,16 @@ func prepareClaim(
 	if pricePerToken.Cmp(big.NewInt(0)) > 0 {
 		if isNativeToken(currencyAddress) {
 			value = big.NewInt(0).Mul(big.NewInt(int64(quantity)), pricePerToken)
-		} 
+		}
 	}
 
 	claimVerification := &ClaimVerification{
-		Value:           				value,
-		Proofs:          				proofs,
-		MaxClaimable:    				maxClaimable,
-		Price:           				pricePerToken,
-		CurrencyAddress: 				currencyAddress,
-		PriceInProof:    				priceInProof,
+		Value:                  value,
+		Proofs:                 proofs,
+		MaxClaimable:           maxClaimable,
+		Price:                  pricePerToken,
+		CurrencyAddress:        currencyAddress,
+		PriceInProof:           priceInProof,
 		CurrencyAddressInProof: currencyAddressInProof,
 	}
 
@@ -443,7 +443,7 @@ func fetchSnapshotEntryForAddress(
 		if err != nil {
 			return nil, err
 		}
-	
+
 		metadata := &ShardedMerkleTreeInfo{}
 		if err := json.Unmarshal(body, &metadata); err != nil {
 			return nil, err
@@ -461,9 +461,7 @@ func fetchSnapshotEntryForAddress(
 func transformResultToClaimCondition(
 	ctx context.Context,
 	pm *abi.IClaimConditionClaimCondition,
-	merkleMetadata interface{},
 	provider *ethclient.Client,
-	storage storage,
 ) (*ClaimConditionOutput, error) {
 	currencyValue, err := fetchCurrencyValue(ctx, provider, pm.Currency.String(), pm.PricePerToken)
 	if err != nil {
@@ -473,16 +471,16 @@ func transformResultToClaimCondition(
 	startTime := time.Unix(pm.StartTimestamp.Int64(), 0)
 
 	return &ClaimConditionOutput{
-		StartTime:                   startTime,
-		MaxClaimableSupply:          pm.MaxClaimableSupply,
-		MaxClaimablePerWallet:       pm.QuantityLimitPerWallet,
-		CurrentMintSupply:           pm.SupplyClaimed,
-		AvailableSupply:             big.NewInt(0).Sub(pm.MaxClaimableSupply, pm.SupplyClaimed),
-		WaitInSeconds:               big.NewInt(0),
-		Price:                       pm.PricePerToken,
-		CurrencyAddress:             pm.Currency.String(),
-		CurrencyMetadata:            currencyValue,
-		MerkleRootHash:              pm.MerkleRoot,
+		StartTime:             startTime,
+		MaxClaimableSupply:    pm.MaxClaimableSupply,
+		MaxClaimablePerWallet: pm.QuantityLimitPerWallet,
+		CurrentMintSupply:     pm.SupplyClaimed,
+		AvailableSupply:       big.NewInt(0).Sub(pm.MaxClaimableSupply, pm.SupplyClaimed),
+		WaitInSeconds:         big.NewInt(0),
+		Price:                 pm.PricePerToken,
+		CurrencyAddress:       pm.Currency.String(),
+		CurrencyMetadata:      currencyValue,
+		MerkleRootHash:        pm.MerkleRoot,
 	}, nil
 }
 

--- a/thirdweb/nft_drop_claim_conditions.go
+++ b/thirdweb/nft_drop_claim_conditions.go
@@ -63,7 +63,7 @@ func (claim *NFTDropClaimConditions) GetActive(ctx context.Context) (*ClaimCondi
 
 	provider := claim.helper.GetProvider()
 	claimCondition, err := transformResultToClaimCondition(
-		context.Background(),
+		ctx,
 		&active,
 		provider,
 	)
@@ -83,7 +83,7 @@ func (claim *NFTDropClaimConditions) Get(ctx context.Context, claimConditionId i
 	provider := claim.helper.GetProvider()
 
 	claimCondition, err := transformResultToClaimCondition(
-		context.Background(),
+		ctx,
 		&condition,
 		provider,
 	)
@@ -128,7 +128,7 @@ func (claim *NFTDropClaimConditions) GetAll(ctx context.Context) ([]*ClaimCondit
 		}
 
 		claimCondition, err := transformResultToClaimCondition(
-			context.Background(),
+			ctx,
 			&mc,
 			provider,
 		)

--- a/thirdweb/nft_drop_claim_conditions.go
+++ b/thirdweb/nft_drop_claim_conditions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+
 	"github.com/thirdweb-dev/go-sdk/v2/abi"
 )
 
@@ -49,18 +50,13 @@ func newNFTDropClaimConditions(address common.Address, provider *ethclient.Clien
 //	fmt.Println("Quantity Limit:", condition.QuantityLimitPerTransaction)
 //	fmt.Println("Price:", condition.Price)
 //	fmt.Println("Wait In Seconds", condition.WaitInSeconds)
-func (claim *NFTDropClaimConditions) GetActive() (*ClaimConditionOutput, error) {
-	id, err := claim.abi.GetActiveClaimConditionId(&bind.CallOpts{})
+func (claim *NFTDropClaimConditions) GetActive(ctx context.Context) (*ClaimConditionOutput, error) {
+	id, err := claim.abi.GetActiveClaimConditionId(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, err
 	}
 
-	active, err := claim.abi.GetClaimConditionById(&bind.CallOpts{}, id)
-	if err != nil {
-		return nil, err
-	}
-
-  merkle, err := claim.getMerkleMetadata()
+	active, err := claim.abi.GetClaimConditionById(&bind.CallOpts{Context: ctx}, id)
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +65,7 @@ func (claim *NFTDropClaimConditions) GetActive() (*ClaimConditionOutput, error) 
 	claimCondition, err := transformResultToClaimCondition(
 		context.Background(),
 		&active,
-		merkle,
 		provider,
-		claim.storage,
 	)
 	if err != nil {
 		return nil, err
@@ -80,24 +74,18 @@ func (claim *NFTDropClaimConditions) GetActive() (*ClaimConditionOutput, error) 
 	return claimCondition, nil
 }
 
-func (claim *NFTDropClaimConditions) Get(claimConditionId int) (*ClaimConditionOutput, error) {
-	condition, err := claim.abi.GetClaimConditionById(&bind.CallOpts{}, big.NewInt(int64(claimConditionId)))
+func (claim *NFTDropClaimConditions) Get(ctx context.Context, claimConditionId int) (*ClaimConditionOutput, error) {
+	condition, err := claim.abi.GetClaimConditionById(&bind.CallOpts{Context: ctx}, big.NewInt(int64(claimConditionId)))
 	if err != nil {
 		return nil, err
 	}
 
 	provider := claim.helper.GetProvider()
-	merkle, err := claim.getMerkleMetadata()
-	if err != nil {
-		return nil, err
-	}
 
 	claimCondition, err := transformResultToClaimCondition(
 		context.Background(),
 		&condition,
-		merkle,
 		provider,
-		claim.storage,
 	)
 	if err != nil {
 		return nil, err
@@ -122,8 +110,8 @@ func (claim *NFTDropClaimConditions) Get(claimConditionId int) (*ClaimConditionO
 //	fmt.Println("Quantity Limit:", condition.QuantityLimitPerTransaction)
 //	fmt.Println("Price:", condition.Price)
 //	fmt.Println("Wait In Seconds", condition.WaitInSeconds)
-func (claim *NFTDropClaimConditions) GetAll() ([]*ClaimConditionOutput, error) {
-	condition, err := claim.abi.ClaimCondition(&bind.CallOpts{})
+func (claim *NFTDropClaimConditions) GetAll(ctx context.Context) ([]*ClaimConditionOutput, error) {
+	condition, err := claim.abi.ClaimCondition(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, err
 	}
@@ -134,22 +122,15 @@ func (claim *NFTDropClaimConditions) GetAll() ([]*ClaimConditionOutput, error) {
 
 	conditions := []*ClaimConditionOutput{}
 	for i := startId; i < count; i++ {
-		mc, err := claim.abi.GetClaimConditionById(&bind.CallOpts{}, big.NewInt(i))
+		mc, err := claim.abi.GetClaimConditionById(&bind.CallOpts{Context: ctx}, big.NewInt(i))
 		if err != nil {
 			return nil, err
 		}
 
-		merkle, err := claim.getMerkleMetadata()
-		if err != nil {
-			return nil, err
-		}
-	
 		claimCondition, err := transformResultToClaimCondition(
 			context.Background(),
 			&mc,
-			merkle,
 			provider,
-			claim.storage,
 		)
 		if err != nil {
 			return nil, err
@@ -162,41 +143,41 @@ func (claim *NFTDropClaimConditions) GetAll() ([]*ClaimConditionOutput, error) {
 }
 
 func (claim *NFTDropClaimConditions) getMerkleMetadata() (*map[string]string, error) {
-	uri, err := claim.abi.InternalContractURI(&bind.CallOpts{});
+	uri, err := claim.abi.InternalContractURI(&bind.CallOpts{})
 	if err != nil {
 		return nil, err
 	}
 
-	body, err := claim.storage.Get(uri);
+	body, err := claim.storage.Get(uri)
 	if err != nil {
 		return nil, err
 	}
 
 	var rawMetadata struct {
 		Merkle map[string]string `json:"merkle"`
-	};
+	}
 	if err := json.Unmarshal(body, &rawMetadata); err != nil {
 		return nil, err
 	}
 
-	return &rawMetadata.Merkle, nil;
+	return &rawMetadata.Merkle, nil
 }
 
 func (claim *NFTDropClaimConditions) GetClaimerProofs(
 	ctx context.Context,
 	claimerAddress string,
 ) (*SnapshotEntryWithProof, error) {
-	claimCondition, err := claim.GetActive()
+	claimCondition, err := claim.GetActive(ctx)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if !strings.HasPrefix(hex.EncodeToString(claimCondition.MerkleRootHash[:]), zeroAddress) {
 		merkleMetadata, err := claim.getMerkleMetadata()
 		if err != nil {
 			return nil, err
 		}
-		
+
 		return fetchSnapshotEntryForAddress(
 			ctx,
 			common.HexToAddress(claimerAddress),

--- a/thirdweb/nft_drop_encoder.go
+++ b/thirdweb/nft_drop_encoder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/thirdweb-dev/go-sdk/v2/abi"
 )
 
@@ -123,11 +124,11 @@ func (encoder *NFTDropEncoder) ApproveClaimTo(ctx context.Context, signerAddress
 //	fmt.Println(tx.Data()) // Ex: get the data field or the nonce field (others are available)
 //	fmt.Println(tx.Nonce())
 func (encoder *NFTDropEncoder) ClaimTo(ctx context.Context, signerAddress string, destinationAddress string, quantity int) (*types.Transaction, error) {
-	active, err := encoder.claimConditions.GetActive()
+	active, err := encoder.claimConditions.GetActive(ctx)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	claimVerification, err := encoder.prepareClaim(ctx, quantity)
 	if err != nil {
 		return nil, err
@@ -167,10 +168,10 @@ func (encoder *NFTDropEncoder) ClaimTo(ctx context.Context, signerAddress string
 	}
 
 	proof := abi.IDropAllowlistProof{
-		Proof: claimVerification.Proofs,
+		Proof:                  claimVerification.Proofs,
 		QuantityLimitPerWallet: claimVerification.MaxClaimable,
-		PricePerToken: claimVerification.Price,
-		Currency: common.HexToAddress(claimVerification.CurrencyAddress),
+		PricePerToken:          claimVerification.Price,
+		Currency:               common.HexToAddress(claimVerification.CurrencyAddress),
 	}
 
 	return encoder.abi.Claim(
@@ -185,7 +186,7 @@ func (encoder *NFTDropEncoder) ClaimTo(ctx context.Context, signerAddress string
 }
 
 func (encoder *NFTDropEncoder) prepareClaim(ctx context.Context, quantity int) (*ClaimVerification, error) {
-	active, err := encoder.claimConditions.GetActive()
+	active, err := encoder.claimConditions.GetActive(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
remove a few unnecessary calls to GetMerkleMetadata() which adds unnecessary latency