### PR TITLE
remove unnecessary metadata from Signature721PayloadOutput

### DIFF
--- a/thirdweb/types.go
+++ b/thirdweb/types.go
@@ -144,19 +144,17 @@ type Signature721PayloadInputWithUri struct {
 	RoyaltyBps           int
 }
 
-
 type Signature721PayloadOutput struct {
-	To                   string             `json:"to"`
-	Price                string            	`json:"price"`
-	CurrencyAddress      string             `json:"currencyAddress"`
-	MintStartTime        int                `json:"mintStartTime"`
-	MintEndTime          int				`json:"mintEndTime"`
-	PrimarySaleRecipient string				`json:"primarySaleRecipient"`
-	Metadata             *NFTMetadataInput  `json:"metadata"`
-	RoyaltyRecipient     string             `json:"royaltyRecipient"`
-	RoyaltyBps           int                `json:"royaltyBps"`
-	Uri                  string             `json:"uri"`
-	Uid                  [32]byte           `json:"uid"`
+	To                   string   `json:"to"`
+	Price                string   `json:"price"`
+	CurrencyAddress      string   `json:"currencyAddress"`
+	MintStartTime        int      `json:"mintStartTime"`
+	MintEndTime          int      `json:"mintEndTime"`
+	PrimarySaleRecipient string   `json:"primarySaleRecipient"`
+	RoyaltyRecipient     string   `json:"royaltyRecipient"`
+	RoyaltyBps           int      `json:"royaltyBps"`
+	Uri                  string   `json:"uri"`
+	Uid                  [32]byte `json:"uid"`
 }
 
 type SignedPayload721 struct {


### PR DESCRIPTION
which allow us to remove an unnecessary metadata fetch from GenerateBatchWithUris